### PR TITLE
Add candlestick plotting utilities

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,8 @@ holidays = "^0.73"
 tqdm = "^4.66.1"
 GitPython = "^3.1.44"
 numpy = "^2.2.6"
+matplotlib = "^3.8"
+mplfinance = "^0.12.10"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.5"

--- a/strategy_lab/plotting/__init__.py
+++ b/strategy_lab/plotting/__init__.py
@@ -1,0 +1,5 @@
+"""Utility functions for plotting stock data."""
+
+from .charts import plot_candlestick
+
+__all__ = ["plot_candlestick"]

--- a/strategy_lab/plotting/charts.py
+++ b/strategy_lab/plotting/charts.py
@@ -1,0 +1,54 @@
+"""Plotting utilities for stock data."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import matplotlib.pyplot as plt
+import mplfinance as mpf
+import polars as pl
+
+
+def plot_candlestick(df: pl.DataFrame, start_date: str, end_date: str) -> plt.Figure:
+    """Plot OHLC candlestick chart between two dates.
+
+    The dataframe must contain ``open``, ``high``, ``low``, ``close`` and
+    ``volume`` columns. A ``date`` column indicates daily data while a
+    ``timestamp`` column indicates intraday data.
+    """
+    if "timestamp" in df.columns:
+        date_col = "timestamp"
+        df = df.with_columns(
+            pl.col(date_col).str.strptime(pl.Datetime, "%Y-%m-%d %H:%M:%S")
+        )
+    elif "date" in df.columns:
+        date_col = "date"
+        df = df.with_columns(
+            pl.col(date_col).str.strptime(pl.Date, "%Y-%m-%d")
+        )
+    else:
+        raise ValueError("DataFrame must contain 'date' or 'timestamp' column")
+
+    if date_col == "timestamp":
+        start = datetime.strptime(start_date, "%Y-%m-%d %H:%M:%S")
+        end = datetime.strptime(end_date, "%Y-%m-%d %H:%M:%S")
+    else:
+        start = datetime.strptime(start_date, "%Y-%m-%d").date()
+        end = datetime.strptime(end_date, "%Y-%m-%d").date()
+
+    df = (
+        df.filter((pl.col(date_col) >= start) & (pl.col(date_col) <= end))
+        .sort(date_col)
+        .rename({date_col: "Date"})
+    )
+    if df.is_empty():
+        raise ValueError("No data available in the specified range")
+
+    pd_df = (
+        df.select(["Date", "open", "high", "low", "close", "volume"])
+        .to_pandas()
+        .set_index("Date")
+    )
+
+    fig, _ = mpf.plot(pd_df, type="candle", volume=True, style="yahoo", returnfig=True)
+    return fig

--- a/strategy_lab/tests/test_plotting.py
+++ b/strategy_lab/tests/test_plotting.py
@@ -1,0 +1,28 @@
+import polars as pl
+from strategy_lab.plotting.charts import plot_candlestick
+
+
+def test_plot_daily_chart():
+    df = pl.DataFrame({
+        "date": ["2024-01-01", "2024-01-02"],
+        "open": [1, 2],
+        "high": [1.5, 2.5],
+        "low": [0.5, 1.5],
+        "close": [1.2, 2.0],
+        "volume": [100, 200],
+    })
+    fig = plot_candlestick(df, "2024-01-01", "2024-01-02")
+    assert fig is not None
+
+
+def test_plot_intraday_chart():
+    df = pl.DataFrame({
+        "timestamp": ["2024-01-01 10:00:00", "2024-01-01 15:00:00"],
+        "open": [1, 2],
+        "high": [1.5, 2.5],
+        "low": [0.5, 1.5],
+        "close": [1.2, 2],
+        "volume": [100, 200],
+    })
+    fig = plot_candlestick(df, "2024-01-01 09:00:00", "2024-01-01 16:00:00")
+    assert fig is not None


### PR DESCRIPTION
## Summary
- add mplfinance-based chart plotting helpers
- include matplotlib and mplfinance as dependencies
- test plotting of intraday and daily charts

## Testing
- `ruff check --fix strategy_lab/plotting/charts.py strategy_lab/plotting/__init__.py strategy_lab/tests/test_plotting.py pyproject.toml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889b3ffe6308327bc6189348c5e9e4e