### PR TITLE
Add candlestick plotting utilities

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,8 @@ holidays = "^0.73"
 tqdm = "^4.66.1"
 GitPython = "^3.1.44"
 numpy = "^2.2.6"
+matplotlib = "^3.8"
+mplfinance = "^0.12.10"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.5"

--- a/strategy_lab/plotting/__init__.py
+++ b/strategy_lab/plotting/__init__.py
@@ -1,0 +1,5 @@
+"""Utility functions for plotting stock data."""
+
+from .charts import plot_candlestick
+
+__all__ = ["plot_candlestick"]

--- a/strategy_lab/plotting/charts.py
+++ b/strategy_lab/plotting/charts.py
@@ -1,0 +1,54 @@
+"""Plotting utilities for stock data."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import matplotlib.pyplot as plt
+import mplfinance as mpf
+import polars as pl
+
+
+def plot_candlestick(df: pl.DataFrame, start_date: str, end_date: str) -> plt.Figure:
+    """Plot OHLC candlestick chart between two dates.
+
+    The dataframe must contain ``open``, ``high``, ``low``, ``close`` and
+    ``volume`` columns. A ``date`` column indicates daily data while a
+    ``timestamp`` column indicates intraday data.
+    """
+    if "timestamp" in df.columns:
+        date_col = "timestamp"
+        df = df.with_columns(
+            pl.col(date_col).str.strptime(pl.Datetime, "%Y-%m-%d %H:%M:%S")
+        )
+    elif "date" in df.columns:
+        date_col = "date"
+        df = df.with_columns(
+            pl.col(date_col).str.strptime(pl.Date, "%Y-%m-%d")
+        )
+    else:
+        raise ValueError("DataFrame must contain 'date' or 'timestamp' column")
+
+    if date_col == "timestamp":
+        start = datetime.strptime(start_date, "%Y-%m-%d %H:%M:%S")
+        end = datetime.strptime(end_date, "%Y-%m-%d %H:%M:%S")
+    else:
+        start = datetime.strptime(start_date, "%Y-%m-%d").date()
+        end = datetime.strptime(end_date, "%Y-%m-%d").date()
+
+    df = (
+        df.filter((pl.col(date_col) >= start) & (pl.col(date_col) <= end))
+        .sort(date_col)
+        .rename({date_col: "Date"})
+    )
+    if df.is_empty():
+        raise ValueError("No data available in the specified range")
+
+    pd_df = (
+        df.select(["Date", "open", "high", "low", "close", "volume"])
+        .to_pandas()
+        .set_index("Date")
+    )
+
+    fig, _ = mpf.plot(pd_df, type="candle", volume=True, style="yahoo", returnfig=True)
+    return fig

--- a/strategy_lab/plotting/charts.py
+++ b/strategy_lab/plotting/charts.py
@@ -18,23 +18,22 @@ def plot_candlestick(df: pl.DataFrame, start_date: str, end_date: str) -> plt.Fi
     """
     if "timestamp" in df.columns:
         date_col = "timestamp"
-        df = df.with_columns(
-            pl.col(date_col).str.strptime(pl.Datetime, "%Y-%m-%d %H:%M:%S")
-        )
-    elif "date" in df.columns:
-        date_col = "date"
-        df = df.with_columns(
-            pl.col(date_col).str.strptime(pl.Date, "%Y-%m-%d")
-        )
-    else:
-        raise ValueError("DataFrame must contain 'date' or 'timestamp' column")
-
-    if date_col == "timestamp":
+        if df.get_column(date_col).dtype != pl.Datetime:
+            df = df.with_columns(
+                pl.col(date_col).str.strptime(pl.Datetime, "%Y-%m-%d %H:%M:%S")
+            )
         start = datetime.strptime(start_date, "%Y-%m-%d %H:%M:%S")
         end = datetime.strptime(end_date, "%Y-%m-%d %H:%M:%S")
-    else:
+    elif "date" in df.columns:
+        date_col = "date"
+        if df.get_column(date_col).dtype != pl.Date:
+            df = df.with_columns(
+                pl.col(date_col).str.strptime(pl.Date, "%Y-%m-%d")
+            )
         start = datetime.strptime(start_date, "%Y-%m-%d").date()
         end = datetime.strptime(end_date, "%Y-%m-%d").date()
+    else:
+        raise ValueError("DataFrame must contain 'date' or 'timestamp' column")
 
     df = (
         df.filter((pl.col(date_col) >= start) & (pl.col(date_col) <= end))

--- a/strategy_lab/plotting/charts.py
+++ b/strategy_lab/plotting/charts.py
@@ -48,6 +48,14 @@ def plot_candlestick(df: pl.DataFrame, start_date: str, end_date: str) -> plt.Fi
         .to_pandas()
         .set_index("Date")
     )
+    pd_df[["open", "high", "low", "close"]] = pd_df[["open", "high", "low", "close"]] / 100
 
-    fig, _ = mpf.plot(pd_df, type="candle", volume=True, style="yahoo", returnfig=True)
+    fig, _ = mpf.plot(
+        pd_df,
+        type="candle",
+        volume=True,
+        style="yahoo",
+        warn_too_much_data=2000,
+        returnfig=True,
+    )
     return fig

--- a/strategy_lab/scripts/plot_stock.py
+++ b/strategy_lab/scripts/plot_stock.py
@@ -1,0 +1,86 @@
+import argparse
+from datetime import datetime
+
+import matplotlib.pyplot as plt
+import polars as pl
+
+from strategy_lab.data.loader import DataLoader
+from strategy_lab.plotting import plot_candlestick
+from strategy_lab.utils.trading_calendar import TradingCalendar
+
+
+def _adjust_dates(calendar: TradingCalendar, start: str, end: str, data_type: str) -> tuple[str, str]:
+    """Adjust provided start and end to valid business days.
+
+    For intraday data, missing time components are filled with default
+    start and end times.
+    """
+    if data_type == "intraday":
+        start_parts = start.split()
+        start_date = start_parts[0]
+        start_time = start_parts[1] if len(start_parts) > 1 else "09:30:00"
+        if start_date not in calendar.trading_days:
+            start_date = calendar.previous(start_date)
+        start = f"{start_date} {start_time}"
+
+        end_parts = end.split()
+        end_date = end_parts[0]
+        end_time = end_parts[1] if len(end_parts) > 1 else "15:55:00"
+        if end_date not in calendar.trading_days:
+            end_date = calendar.previous(end_date)
+        end = f"{end_date} {end_time}"
+    else:
+        if start not in calendar.trading_days:
+            start = calendar.previous(start)
+        if end not in calendar.trading_days:
+            end = calendar.previous(end)
+    return start, end
+
+
+def _load_data(loader: DataLoader, data_type: str, ticker: str, start: str, end: str) -> pl.DataFrame:
+    """Load data for the ticker between start and end."""
+    if data_type == "intraday":
+        df = loader.load_intraday(ticker, start.split()[0], end.split()[0])
+        start_dt = datetime.strptime(start, "%Y-%m-%d %H:%M:%S")
+        end_dt = datetime.strptime(end, "%Y-%m-%d %H:%M:%S")
+        return df.filter((pl.col("timestamp") >= start_dt) & (pl.col("timestamp") <= end_dt))
+    return loader.load_eod(ticker, start_date=start, end_date=end)
+
+
+def plot_stock(
+    ticker: str,
+    data_type: str,
+    start: str,
+    end: str,
+    loader: DataLoader | None = None,
+    calendar: TradingCalendar | None = None,
+    show: bool = True,
+) -> plt.Figure:
+    """Plot candlestick chart for a ticker."""
+    if calendar is None:
+        calendar = TradingCalendar()
+    start, end = _adjust_dates(calendar, start, end, data_type)
+
+    if loader is None:
+        loader = DataLoader(calendar=calendar)
+
+    df = _load_data(loader, data_type, ticker, start, end)
+    fig = plot_candlestick(df, start, end)
+    if show:
+        plt.show()
+    return fig
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Plot candlestick charts.")
+    parser.add_argument("ticker", type=str, help="Stock ticker symbol")
+    parser.add_argument("data_type", choices=["eod", "intraday"], help="Data type")
+    parser.add_argument("start", type=str, help="Start date or datetime")
+    parser.add_argument("end", type=str, help="End date or datetime")
+    args = parser.parse_args()
+
+    plot_stock(args.ticker, args.data_type, args.start, args.end)
+
+
+if __name__ == "__main__":
+    main()

--- a/strategy_lab/tests/test_plot_stock.py
+++ b/strategy_lab/tests/test_plot_stock.py
@@ -1,0 +1,57 @@
+import polars as pl
+from strategy_lab.scripts.plot_stock import _adjust_dates, plot_stock
+
+
+class DummyCalendar:
+    def __init__(self):
+        self.trading_days = ["2024-01-02", "2024-01-03"]
+
+    def previous(self, date: str) -> str:
+        for d in reversed(self.trading_days):
+            if d < date:
+                return d
+        return self.trading_days[0]
+
+
+class DummyLoader:
+    def load_eod(self, ticker, start_date=None, end_date=None, **kwargs):
+        return pl.DataFrame({
+            "date": ["2024-01-02", "2024-01-03"],
+            "open": [1, 2],
+            "high": [1.5, 2.5],
+            "low": [0.5, 1.5],
+            "close": [1.2, 2.0],
+            "volume": [100, 200],
+        })
+
+    def load_intraday(self, ticker, start_date, end_date, **kwargs):
+        return pl.DataFrame({
+            "timestamp": ["2024-01-02 09:30:00", "2024-01-02 15:55:00"],
+            "open": [1, 2],
+            "high": [1.5, 2.5],
+            "low": [0.5, 1.5],
+            "close": [1.2, 2.0],
+            "volume": [100, 200],
+        })
+
+
+def test_adjust_dates_intraday():
+    cal = DummyCalendar()
+    start, end = _adjust_dates(cal, "2024-01-01", "2024-01-01", "intraday")
+    assert start == "2024-01-02 09:30:00"
+    assert end == "2024-01-02 15:55:00"
+
+
+def test_plot_stock_returns_figure():
+    cal = DummyCalendar()
+    loader = DummyLoader()
+    fig = plot_stock(
+        "AAPL",
+        "eod",
+        "2024-01-01",
+        "2024-01-03",
+        loader=loader,
+        calendar=cal,
+        show=False,
+    )
+    assert fig is not None

--- a/strategy_lab/tests/test_plot_stock.py
+++ b/strategy_lab/tests/test_plot_stock.py
@@ -1,3 +1,5 @@
+from datetime import datetime, date
+
 import polars as pl
 from strategy_lab.scripts.plot_stock import _adjust_dates, plot_stock
 
@@ -15,24 +17,31 @@ class DummyCalendar:
 
 class DummyLoader:
     def load_eod(self, ticker, start_date=None, end_date=None, **kwargs):
-        return pl.DataFrame({
-            "date": ["2024-01-02", "2024-01-03"],
-            "open": [1, 2],
-            "high": [1.5, 2.5],
-            "low": [0.5, 1.5],
-            "close": [1.2, 2.0],
-            "volume": [100, 200],
-        })
+        return pl.DataFrame(
+            {
+                "date": [date(2024, 1, 2), date(2024, 1, 3)],
+                "open": [1, 2],
+                "high": [1.5, 2.5],
+                "low": [0.5, 1.5],
+                "close": [1.2, 2.0],
+                "volume": [100, 200],
+            }
+        )
 
     def load_intraday(self, ticker, start_date, end_date, **kwargs):
-        return pl.DataFrame({
-            "timestamp": ["2024-01-02 09:30:00", "2024-01-02 15:55:00"],
-            "open": [1, 2],
-            "high": [1.5, 2.5],
-            "low": [0.5, 1.5],
-            "close": [1.2, 2.0],
-            "volume": [100, 200],
-        })
+        return pl.DataFrame(
+            {
+                "timestamp": [
+                    datetime(2024, 1, 2, 9, 30, 0),
+                    datetime(2024, 1, 2, 15, 55, 0),
+                ],
+                "open": [1, 2],
+                "high": [1.5, 2.5],
+                "low": [0.5, 1.5],
+                "close": [1.2, 2.0],
+                "volume": [100, 200],
+            }
+        )
 
 
 def test_adjust_dates_intraday():

--- a/strategy_lab/tests/test_plotting.py
+++ b/strategy_lab/tests/test_plotting.py
@@ -1,28 +1,39 @@
+from datetime import datetime, date
+
 import polars as pl
 from strategy_lab.plotting.charts import plot_candlestick
 
 
 def test_plot_daily_chart():
-    df = pl.DataFrame({
-        "date": ["2024-01-01", "2024-01-02"],
-        "open": [1, 2],
-        "high": [1.5, 2.5],
-        "low": [0.5, 1.5],
-        "close": [1.2, 2.0],
-        "volume": [100, 200],
-    })
+    df = pl.DataFrame(
+        {
+            "date": [date(2024, 1, 1), date(2024, 1, 2)],
+            "open": [1, 2],
+            "high": [1.5, 2.5],
+            "low": [0.5, 1.5],
+            "close": [1.2, 2.0],
+            "volume": [100, 200],
+        }
+    )
     fig = plot_candlestick(df, "2024-01-01", "2024-01-02")
     assert fig is not None
 
 
 def test_plot_intraday_chart():
-    df = pl.DataFrame({
-        "timestamp": ["2024-01-01 10:00:00", "2024-01-01 15:00:00"],
-        "open": [1, 2],
-        "high": [1.5, 2.5],
-        "low": [0.5, 1.5],
-        "close": [1.2, 2],
-        "volume": [100, 200],
-    })
-    fig = plot_candlestick(df, "2024-01-01 09:00:00", "2024-01-01 16:00:00")
+    df = pl.DataFrame(
+        {
+            "timestamp": [
+                datetime(2024, 1, 1, 10, 0, 0),
+                datetime(2024, 1, 1, 15, 0, 0),
+            ],
+            "open": [1, 2],
+            "high": [1.5, 2.5],
+            "low": [0.5, 1.5],
+            "close": [1.2, 2],
+            "volume": [100, 200],
+        }
+    )
+    fig = plot_candlestick(
+        df, "2024-01-01 09:00:00", "2024-01-01 16:00:00"
+    )
     assert fig is not None

--- a/strategy_lab/tests/test_plotting.py
+++ b/strategy_lab/tests/test_plotting.py
@@ -1,10 +1,21 @@
 from datetime import datetime, date
 
+import matplotlib.pyplot as plt
+import mplfinance as mpf
 import polars as pl
 from strategy_lab.plotting.charts import plot_candlestick
 
 
-def test_plot_daily_chart():
+def test_plot_daily_chart(monkeypatch):
+    captured = {}
+
+    def fake_plot(data, *args, **kwargs):
+        captured["data"] = data
+        captured["kwargs"] = kwargs
+        return plt.figure(), []
+
+    monkeypatch.setattr(mpf, "plot", fake_plot)
+
     df = pl.DataFrame(
         {
             "date": [date(2024, 1, 1), date(2024, 1, 2)],
@@ -17,9 +28,21 @@ def test_plot_daily_chart():
     )
     fig = plot_candlestick(df, "2024-01-01", "2024-01-02")
     assert fig is not None
+    pd_df = captured["data"]
+    assert pd_df["open"].iloc[0] == 0.01
+    assert captured["kwargs"]["warn_too_much_data"] == 2000
 
 
-def test_plot_intraday_chart():
+def test_plot_intraday_chart(monkeypatch):
+    captured = {}
+
+    def fake_plot(data, *args, **kwargs):
+        captured["data"] = data
+        captured["kwargs"] = kwargs
+        return plt.figure(), []
+
+    monkeypatch.setattr(mpf, "plot", fake_plot)
+
     df = pl.DataFrame(
         {
             "timestamp": [
@@ -37,3 +60,6 @@ def test_plot_intraday_chart():
         df, "2024-01-01 09:00:00", "2024-01-01 16:00:00"
     )
     assert fig is not None
+    pd_df = captured["data"]
+    assert pd_df["open"].iloc[0] == 0.01
+    assert captured["kwargs"]["warn_too_much_data"] == 2000

--- a/strategy_lab/tests/test_plotting.py
+++ b/strategy_lab/tests/test_plotting.py
@@ -1,0 +1,28 @@
+import polars as pl
+from strategy_lab.plotting.charts import plot_candlestick
+
+
+def test_plot_daily_chart():
+    df = pl.DataFrame({
+        "date": ["2024-01-01", "2024-01-02"],
+        "open": [1, 2],
+        "high": [1.5, 2.5],
+        "low": [0.5, 1.5],
+        "close": [1.2, 2.0],
+        "volume": [100, 200],
+    })
+    fig = plot_candlestick(df, "2024-01-01", "2024-01-02")
+    assert fig is not None
+
+
+def test_plot_intraday_chart():
+    df = pl.DataFrame({
+        "timestamp": ["2024-01-01 10:00:00", "2024-01-01 15:00:00"],
+        "open": [1, 2],
+        "high": [1.5, 2.5],
+        "low": [0.5, 1.5],
+        "close": [1.2, 2],
+        "volume": [100, 200],
+    })
+    fig = plot_candlestick(df, "2024-01-01 09:00:00", "2024-01-01 16:00:00")
+    assert fig is not None


### PR DESCRIPTION
## Summary
- add mplfinance-based chart plotting helpers
- include matplotlib and mplfinance as dependencies
- test plotting of intraday and daily charts
- implement `plot_stock` CLI to load data via `DataLoader` and plot charts

## Testing
- `ruff check --fix strategy_lab/scripts/plot_stock.py strategy_lab/tests/test_plot_stock.py strategy_lab/plotting/charts.py strategy_lab/plotting/__init__.py pyproject.toml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6889b3ffe6308327bc6189348c5e9e4e