### PR TITLE
Add support/resistance zone detection and chart overlays

### DIFF
--- a/strategy_lab/scripts/plot_stock.py
+++ b/strategy_lab/scripts/plot_stock.py
@@ -1,11 +1,13 @@
 import argparse
 from datetime import datetime
+from typing import List
 
 import matplotlib.pyplot as plt
 import polars as pl
 
 from strategy_lab.data.loader import DataLoader
 from strategy_lab.plotting import plot_candlestick
+from strategy_lab.selection.support_resistance import PivotArea, detect_areas
 from strategy_lab.utils.trading_calendar import TradingCalendar
 
 
@@ -47,6 +49,13 @@ def _load_data(loader: DataLoader, data_type: str, ticker: str, start: str, end:
     return loader.load_eod(ticker, start_date=start, end_date=end)
 
 
+def _draw_sr_areas(fig: plt.Figure, areas: List[PivotArea]) -> None:
+    """Overlay support/resistance areas on an existing figure."""
+    ax = fig.axes[0]
+    for area in areas:
+        ax.axhspan(area.lower / 100, area.upper / 100, color="gold", alpha=0.2)
+
+
 def plot_stock(
     ticker: str,
     data_type: str,
@@ -54,9 +63,14 @@ def plot_stock(
     end: str,
     loader: DataLoader | None = None,
     calendar: TradingCalendar | None = None,
+    sr_areas: List[PivotArea] | None = None,
     show: bool = True,
 ) -> plt.Figure:
-    """Plot candlestick chart for a ticker."""
+    """Plot candlestick chart for a ticker.
+
+    When ``sr_areas`` is provided, the zones are drawn on top of the
+    candlestick chart.
+    """
     if calendar is None:
         calendar = TradingCalendar()
     start, end = _adjust_dates(calendar, start, end, data_type)
@@ -66,6 +80,8 @@ def plot_stock(
 
     df = _load_data(loader, data_type, ticker, start, end)
     fig = plot_candlestick(df, start, end)
+    if sr_areas:
+        _draw_sr_areas(fig, sr_areas)
     if show:
         plt.show()
     return fig
@@ -77,9 +93,53 @@ def main() -> None:
     parser.add_argument("data_type", choices=["eod", "intraday"], help="Data type")
     parser.add_argument("start", type=str, help="Start date or datetime")
     parser.add_argument("end", type=str, help="End date or datetime")
+    parser.add_argument(
+        "--sr",
+        action="store_true",
+        help="Overlay support/resistance areas",
+    )
+    parser.add_argument(
+        "--sr-factor",
+        type=float,
+        default=3.0,
+        help="JL penetration factor",
+    )
+    parser.add_argument(
+        "--sr-threshold",
+        type=float,
+        default=1.0,
+        help="Clustering threshold in dollars",
+    )
+    parser.add_argument(
+        "--sr-buffer",
+        type=float,
+        default=0.5,
+        help="Buffer above/below pivot price in dollars",
+    )
     args = parser.parse_args()
 
-    plot_stock(args.ticker, args.data_type, args.start, args.end)
+    sr_areas = None
+    if args.sr:
+        threshold = int(args.sr_threshold * 100)
+        buffer = int(args.sr_buffer * 100)
+        sr_areas = detect_areas(
+            args.ticker,
+            args.start.split()[0],
+            args.end.split()[0],
+            args.end,
+            args.sr_factor,
+            threshold,
+            buffer,
+            data_type=args.data_type,
+        )
+
+    plot_stock(
+        args.ticker,
+        args.data_type,
+        args.start,
+        args.end,
+        sr_areas=sr_areas,
+    )
 
 
 if __name__ == "__main__":

--- a/strategy_lab/scripts/plot_stock.py
+++ b/strategy_lab/scripts/plot_stock.py
@@ -8,35 +8,7 @@ import polars as pl
 from strategy_lab.data.loader import DataLoader
 from strategy_lab.plotting import plot_candlestick
 from strategy_lab.selection.support_resistance import PivotArea, detect_areas
-from strategy_lab.utils.trading_calendar import TradingCalendar
-
-
-def _adjust_dates(calendar: TradingCalendar, start: str, end: str, data_type: str) -> tuple[str, str]:
-    """Adjust provided start and end to valid business days.
-
-    For intraday data, missing time components are filled with default
-    start and end times.
-    """
-    if data_type == "intraday":
-        start_parts = start.split()
-        start_date = start_parts[0]
-        start_time = start_parts[1] if len(start_parts) > 1 else "09:30:00"
-        if start_date not in calendar.trading_days:
-            start_date = calendar.previous(start_date)
-        start = f"{start_date} {start_time}"
-
-        end_parts = end.split()
-        end_date = end_parts[0]
-        end_time = end_parts[1] if len(end_parts) > 1 else "15:55:00"
-        if end_date not in calendar.trading_days:
-            end_date = calendar.previous(end_date)
-        end = f"{end_date} {end_time}"
-    else:
-        if start not in calendar.trading_days:
-            start = calendar.previous(start)
-        if end not in calendar.trading_days:
-            end = calendar.previous(end)
-    return start, end
+from strategy_lab.utils.trading_calendar import TradingCalendar, adjust_start_end
 
 
 def _load_data(loader: DataLoader, data_type: str, ticker: str, start: str, end: str) -> pl.DataFrame:
@@ -73,7 +45,7 @@ def plot_stock(
     """
     if calendar is None:
         calendar = TradingCalendar()
-    start, end = _adjust_dates(calendar, start, end, data_type)
+    start, end = adjust_start_end(calendar, start, end, data_type)
 
     if loader is None:
         loader = DataLoader(calendar=calendar)

--- a/strategy_lab/scripts/plot_stock.py
+++ b/strategy_lab/scripts/plot_stock.py
@@ -53,7 +53,7 @@ def _draw_sr_areas(fig: plt.Figure, areas: List[PivotArea]) -> None:
     """Overlay support/resistance areas on an existing figure."""
     ax = fig.axes[0]
     for area in areas:
-        ax.axhspan(area.lower / 100, area.upper / 100, color="gold", alpha=0.2)
+        ax.axhspan(area.lower / 100, area.upper / 100, color="darkgoldenrod", alpha=0.2)
 
 
 def plot_stock(

--- a/strategy_lab/selection/support_resistance.py
+++ b/strategy_lab/selection/support_resistance.py
@@ -16,7 +16,6 @@ class PivotArea:
     lower: float
     upper: float
     pivots: List[JLPivot]
-    area_type: str  # 'support' or 'resistance'
 
 
 def extract_pivots(jl: StxJL) -> List[JLPivot]:
@@ -45,40 +44,29 @@ def extract_pivots(jl: StxJL) -> List[JLPivot]:
 
 
 def group_pivots(pivots: List[JLPivot], threshold: float, buffer: float) -> List[PivotArea]:
-    """Group pivots into support/resistance areas.
+    """Group pivots into combined support/resistance areas.
 
-    Pivots are first separated by type (support vs. resistance). Clusters are
-    only returned when they contain more than a single pivot.
+    Pivots of both types are clustered together when they fall within
+    ``threshold`` of the running average price of an existing cluster. Clusters
+    containing only a single pivot are ignored.
     """
 
-    def cluster(pivots_subset: List[JLPivot], area_type: str) -> List[PivotArea]:
-        clusters: List[List[JLPivot]] = []
-        for p in pivots_subset:
-            for cl in clusters:
-                avg = sum(x.price for x in cl) / len(cl)
-                if abs(p.price - avg) <= threshold:
-                    cl.append(p)
-                    break
-            else:
-                clusters.append([p])
-
-        areas: List[PivotArea] = []
+    clusters: List[List[JLPivot]] = []
+    for p in pivots:
         for cl in clusters:
-            if len(cl) <= 1:
-                continue
-            prices = [p.price for p in cl]
-            areas.append(
-                PivotArea(min(prices) - buffer, max(prices) + buffer, cl, area_type)
-            )
-        return areas
+            avg = sum(x.price for x in cl) / len(cl)
+            if abs(p.price - avg) <= threshold:
+                cl.append(p)
+                break
+        else:
+            clusters.append([p])
 
-    up_states = {StxJL.NRa, StxJL.UT}
-    dn_states = {StxJL.NRe, StxJL.DT}
-
-    support_pivots = [p for p in pivots if p.state in dn_states]
-    resistance_pivots = [p for p in pivots if p.state in up_states]
-
-    areas = cluster(support_pivots, "support") + cluster(resistance_pivots, "resistance")
+    areas: List[PivotArea] = []
+    for cl in clusters:
+        if len(cl) <= 1:
+            continue
+        prices = [p.price for p in cl]
+        areas.append(PivotArea(min(prices) - buffer, max(prices) + buffer, cl))
     return areas
 
 
@@ -154,6 +142,6 @@ if __name__ == "__main__":
     )
 
     for area in areas:
-        print(f"{area.area_type.capitalize()} {area.lower/100:.2f} - {area.upper/100:.2f}")
+        print(f"Area {area.lower/100:.2f} - {area.upper/100:.2f}")
         for p in area.pivots:
             print(f"  {p.dt} state:{p.state} price:{p.price/100:.2f}")

--- a/strategy_lab/selection/support_resistance.py
+++ b/strategy_lab/selection/support_resistance.py
@@ -9,6 +9,7 @@ import polars as pl
 
 from strategy_lab.data.loader import DataLoader
 from strategy_lab.selection.jl_pivotal_points import StxJL, JLPivot
+from strategy_lab.utils.trading_calendar import TradingCalendar, adjust_start_end
 
 
 @dataclass
@@ -128,12 +129,15 @@ if __name__ == "__main__":
     parser.add_argument("--area", type=float, required=True, help="Area buffer above/below pivot price in dollars")
     args = parser.parse_args()
 
+    cal = TradingCalendar()
+    start, end = adjust_start_end(cal, args.start_date, args.end_date, args.data_type)
+
     threshold = int(args.threshold * 100)
     buffer = int(args.area * 100)
     areas = detect_areas(
         args.stk,
-        args.start_date,
-        args.end_date,
+        start,
+        end,
         args.dt,
         args.factor,
         threshold,

--- a/strategy_lab/selection/support_resistance.py
+++ b/strategy_lab/selection/support_resistance.py
@@ -9,7 +9,11 @@ import polars as pl
 
 from strategy_lab.data.loader import DataLoader
 from strategy_lab.selection.jl_pivotal_points import StxJL, JLPivot
-from strategy_lab.utils.trading_calendar import TradingCalendar, adjust_start_end
+from strategy_lab.utils.trading_calendar import (
+    TradingCalendar,
+    adjust_calc_dt,
+    adjust_start_end,
+)
 
 
 @dataclass
@@ -80,8 +84,12 @@ def detect_areas(
     threshold: float,
     buffer: float,
     data_type: str = "eod",
+    calendar: TradingCalendar | None = None,
 ) -> List[PivotArea]:
-    loader = DataLoader()
+    if calendar is None:
+        calendar = TradingCalendar()
+    calc_dt = adjust_calc_dt(calendar, calc_dt, data_type)
+    loader = DataLoader(calendar=calendar)
     start_dt = datetime.fromisoformat(start_date).date()
     end_dt = datetime.fromisoformat(end_date).date()
 

--- a/strategy_lab/tests/test_plot_stock.py
+++ b/strategy_lab/tests/test_plot_stock.py
@@ -2,7 +2,7 @@ from datetime import datetime, date
 
 import polars as pl
 from strategy_lab.scripts.plot_stock import plot_stock
-from strategy_lab.utils.trading_calendar import adjust_calc_dt, adjust_start_end
+from strategy_lab.utils.trading_calendar import adjust_dt
 
 
 class DummyCalendar:
@@ -14,6 +14,12 @@ class DummyCalendar:
             if d < date:
                 return d
         return self.trading_days[0]
+
+    def next(self, date: str) -> str:
+        for d in self.trading_days:
+            if d > date:
+                return d
+        return self.trading_days[-1]
 
 
 class DummyLoader:
@@ -45,22 +51,23 @@ class DummyLoader:
         )
 
 
-def test_adjust_dates_intraday():
+def test_adjust_dt_intraday():
     cal = DummyCalendar()
-    start, end = adjust_start_end(cal, "2024-01-01", "2024-01-01", "intraday")
+    start = adjust_dt(cal, "2024-01-01", True, is_start=True)
+    end = adjust_dt(cal, "2024-01-01", True)
     assert start == "2024-01-02 09:30:00"
     assert end == "2024-01-02 15:55:00"
 
 
-def test_adjust_calc_dt_intraday():
+def test_adjust_dt_intraday_default_close():
     cal = DummyCalendar()
-    dt = adjust_calc_dt(cal, "2024-01-01", "intraday")
+    dt = adjust_dt(cal, "2024-01-01", True)
     assert dt == "2024-01-02 15:55:00"
 
 
-def test_adjust_calc_dt_eod():
+def test_adjust_dt_eod():
     cal = DummyCalendar()
-    dt = adjust_calc_dt(cal, "2024-01-01", "eod")
+    dt = adjust_dt(cal, "2024-01-01")
     assert dt == "2024-01-02"
 
 

--- a/strategy_lab/tests/test_plot_stock.py
+++ b/strategy_lab/tests/test_plot_stock.py
@@ -1,7 +1,8 @@
 from datetime import datetime, date
 
 import polars as pl
-from strategy_lab.scripts.plot_stock import _adjust_dates, plot_stock
+from strategy_lab.scripts.plot_stock import plot_stock
+from strategy_lab.utils.trading_calendar import adjust_start_end
 
 
 class DummyCalendar:
@@ -46,7 +47,7 @@ class DummyLoader:
 
 def test_adjust_dates_intraday():
     cal = DummyCalendar()
-    start, end = _adjust_dates(cal, "2024-01-01", "2024-01-01", "intraday")
+    start, end = adjust_start_end(cal, "2024-01-01", "2024-01-01", "intraday")
     assert start == "2024-01-02 09:30:00"
     assert end == "2024-01-02 15:55:00"
 

--- a/strategy_lab/tests/test_plot_stock.py
+++ b/strategy_lab/tests/test_plot_stock.py
@@ -2,7 +2,7 @@ from datetime import datetime, date
 
 import polars as pl
 from strategy_lab.scripts.plot_stock import plot_stock
-from strategy_lab.utils.trading_calendar import adjust_start_end
+from strategy_lab.utils.trading_calendar import adjust_calc_dt, adjust_start_end
 
 
 class DummyCalendar:
@@ -50,6 +50,18 @@ def test_adjust_dates_intraday():
     start, end = adjust_start_end(cal, "2024-01-01", "2024-01-01", "intraday")
     assert start == "2024-01-02 09:30:00"
     assert end == "2024-01-02 15:55:00"
+
+
+def test_adjust_calc_dt_intraday():
+    cal = DummyCalendar()
+    dt = adjust_calc_dt(cal, "2024-01-01", "intraday")
+    assert dt == "2024-01-02 15:55:00"
+
+
+def test_adjust_calc_dt_eod():
+    cal = DummyCalendar()
+    dt = adjust_calc_dt(cal, "2024-01-01", "eod")
+    assert dt == "2024-01-02"
 
 
 def test_plot_stock_returns_figure():

--- a/strategy_lab/tests/test_support_resistance.py
+++ b/strategy_lab/tests/test_support_resistance.py
@@ -11,14 +11,9 @@ def test_group_pivots_simple():
         JLPivot("2024-01-05", StxJL.NRa, 150, 1),
     ]
     areas = group_pivots(pivots, threshold=3, buffer=1)
-    assert len(areas) == 2
-    types = {area.area_type for area in areas}
-    assert {"support", "resistance"} == types
-    for area in areas:
-        if area.area_type == "support":
-            assert len(area.pivots) == 2
-            assert area.lower == 99
-            assert area.upper == 102
-        elif area.area_type == "resistance":
-            assert len(area.pivots) == 2
+    assert len(areas) == 1
+    area = areas[0]
+    assert len(area.pivots) == 4
+    assert area.lower == 99
+    assert area.upper == 104
 

--- a/strategy_lab/utils/trading_calendar.py
+++ b/strategy_lab/utils/trading_calendar.py
@@ -78,51 +78,30 @@ class TradingCalendar:
         raise ValueError("No valid business date found.")
 
 
-def adjust_start_end(
-    calendar: TradingCalendar, start: str, end: str, data_type: str
-) -> tuple[str, str]:
-    """Normalize start and end for data loading.
+def adjust_dt(
+    calendar: TradingCalendar,
+    dt: str,
+    is_intraday: bool = False,
+    is_start: bool = False,
+) -> str:
+    """Normalize a date or datetime string.
 
-    If either ``start`` or ``end`` fall on non-trading days they are shifted to
-    the previous business day. When ``data_type`` is ``"intraday"`` and time
-    components are missing, default market open/close times are appended.
+    ``dt`` is shifted to the previous business day when ``is_start`` is
+    ``False`` or the next business day when ``True`` if it falls on a holiday.
+    For intraday data lacking a time component, ``09:30:00`` is appended for
+    start dates and ``15:55:00`` for end dates.
     """
-    if data_type == "intraday":
-        start_parts = start.split()
-        start_date = start_parts[0]
-        start_time = start_parts[1] if len(start_parts) > 1 else "09:30:00"
-        if start_date not in calendar.trading_days:
-            start_date = calendar.previous(start_date)
-        start = f"{start_date} {start_time}"
 
-        end_parts = end.split()
-        end_date = end_parts[0]
-        end_time = end_parts[1] if len(end_parts) > 1 else "15:55:00"
-        if end_date not in calendar.trading_days:
-            end_date = calendar.previous(end_date)
-        end = f"{end_date} {end_time}"
-    else:
-        if start not in calendar.trading_days:
-            start = calendar.previous(start)
-        if end not in calendar.trading_days:
-            end = calendar.previous(end)
-    return start, end
-
-
-def adjust_calc_dt(calendar: TradingCalendar, dt: str, data_type: str) -> str:
-    """Normalize ``calc_dt`` for support/resistance detection.
-
-    If ``dt`` falls on a non-trading day it is shifted to the previous business
-    day. When ``data_type`` is ``"intraday"`` and the time component is
-    missing, a default market close time of ``15:55:00`` is appended.
-    """
-    if data_type == "intraday":
-        parts = dt.split()
-        date = parts[0]
-        time = parts[1] if len(parts) > 1 else "15:55:00"
-        if date not in calendar.trading_days:
+    parts = dt.split()
+    date = parts[0]
+    if date not in calendar.trading_days:
+        if is_start:
+            date = calendar.next(date)
+        else:
             date = calendar.previous(date)
+
+    if is_intraday:
+        time = parts[1] if len(parts) > 1 else ("09:30:00" if is_start else "15:55:00")
         return f"{date} {time}"
-    if dt not in calendar.trading_days:
-        dt = calendar.previous(dt)
-    return dt
+
+    return date

--- a/strategy_lab/utils/trading_calendar.py
+++ b/strategy_lab/utils/trading_calendar.py
@@ -107,3 +107,22 @@ def adjust_start_end(
         if end not in calendar.trading_days:
             end = calendar.previous(end)
     return start, end
+
+
+def adjust_calc_dt(calendar: TradingCalendar, dt: str, data_type: str) -> str:
+    """Normalize ``calc_dt`` for support/resistance detection.
+
+    If ``dt`` falls on a non-trading day it is shifted to the previous business
+    day. When ``data_type`` is ``"intraday"`` and the time component is
+    missing, a default market close time of ``15:55:00`` is appended.
+    """
+    if data_type == "intraday":
+        parts = dt.split()
+        date = parts[0]
+        time = parts[1] if len(parts) > 1 else "15:55:00"
+        if date not in calendar.trading_days:
+            date = calendar.previous(date)
+        return f"{date} {time}"
+    if dt not in calendar.trading_days:
+        dt = calendar.previous(dt)
+    return dt

--- a/strategy_lab/utils/trading_calendar.py
+++ b/strategy_lab/utils/trading_calendar.py
@@ -76,3 +76,34 @@ class TradingCalendar:
 
         # If the list is empty or today is before the first trading day
         raise ValueError("No valid business date found.")
+
+
+def adjust_start_end(
+    calendar: TradingCalendar, start: str, end: str, data_type: str
+) -> tuple[str, str]:
+    """Normalize start and end for data loading.
+
+    If either ``start`` or ``end`` fall on non-trading days they are shifted to
+    the previous business day. When ``data_type`` is ``"intraday"`` and time
+    components are missing, default market open/close times are appended.
+    """
+    if data_type == "intraday":
+        start_parts = start.split()
+        start_date = start_parts[0]
+        start_time = start_parts[1] if len(start_parts) > 1 else "09:30:00"
+        if start_date not in calendar.trading_days:
+            start_date = calendar.previous(start_date)
+        start = f"{start_date} {start_time}"
+
+        end_parts = end.split()
+        end_date = end_parts[0]
+        end_time = end_parts[1] if len(end_parts) > 1 else "15:55:00"
+        if end_date not in calendar.trading_days:
+            end_date = calendar.previous(end_date)
+        end = f"{end_date} {end_time}"
+    else:
+        if start not in calendar.trading_days:
+            start = calendar.previous(start)
+        if end not in calendar.trading_days:
+            end = calendar.previous(end)
+    return start, end


### PR DESCRIPTION
## Summary
- Merge support and resistance pivots into unified price zones
- Add option to overlay support/resistance zones on plotted candlestick charts
- Update tests for new zone model

## Testing
- `ruff check strategy_lab/selection/support_resistance.py strategy_lab/scripts/plot_stock.py strategy_lab/tests/test_support_resistance.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f23d2dfb48327a54b7498770b258e